### PR TITLE
Fixed the build, TryFrom seems to be feature gated in num_bigint

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,2 @@
 [target.thumbv7em-none-eabihf]
-rustflags = ["-C", "link-arg=-Tdmcp/stm32_program.ld"]
+rustflags = ["--cfg", "has_try_from", "-C", "link-arg=-Tdmcp/stm32_program.ld"]


### PR DESCRIPTION
Fixed the build. It seems `num_bigint` gates behind `TryFrom`. I'm not sure if this is the right fix, as I would suspect this is something that should be auto-detected.

```
pleb@gamey ~/test/rscalc $ make
cargo build --target thumbv7em-none-eabihf -Z build-std=core,alloc --release --no-default-features --features dm42
   Compiling core v0.0.0 (/usr/lib/rust/1.48.0/lib/rustlib/src/rust/library/core)
   Compiling rscalc v0.1.0 (/home/pleb/test/rscalc)
   Compiling rustc-std-workspace-core v1.99.0 (/usr/lib/rust/1.48.0/lib/rustlib/src/rust/library/rustc-std-workspace-core)
   Compiling compiler_builtins v0.1.35
   Compiling alloc v0.0.0 (/usr/lib/rust/1.48.0/lib/rustlib/src/rust/library/alloc)
   Compiling scopeguard v1.1.0
   Compiling num-traits v0.2.14
   Compiling spin v0.5.2
   Compiling intel_dfp v0.1.0 (/home/pleb/test/rscalc/intel_dfp)
   Compiling lock_api v0.3.4
   Compiling lazy_static v1.4.0
   Compiling spinning_top v0.1.1
   Compiling linked_list_allocator v0.8.8
   Compiling num-integer v0.1.44
   Compiling num-bigint v0.3.1
   Compiling chrono v0.4.19
   Compiling rscalc_math v0.1.0 (/home/pleb/test/rscalc/math)
error[E0432]: unresolved import `num_bigint::TryFromBigIntError`
 --> math/src/error.rs:2:5
  |
2 | use num_bigint::TryFromBigIntError;
  |     ^^^^^^^^^^^^------------------
  |     |           |
  |     |           help: a similar name exists in the module: `ParseBigIntError`
  |     no `TryFromBigIntError` in the root

error[E0207]: the type parameter `T` is not constrained by the impl trait, self type, or predicates
  --> math/src/error.rs:57:6
   |
57 | impl<T> From<TryFromBigIntError<T>> for Error {
   |      ^ unconstrained type parameter

error: aborting due to 2 previous errors

Some errors have detailed explanations: E0207, E0432.
For more information about an error, try `rustc --explain E0207`.
error: could not compile `rscalc_math`
```